### PR TITLE
Add Visual Studio temp files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+.vs/


### PR DESCRIPTION
There's been a few instances where this project has been opened in Visual Studio. When that happens Visual Studio creates a `.vs/` directory with temporary files about the project which gets included when those users contribute their changes.

This adds the `.vs/` directory to the `.gitignore` file so that others can avoid contributing that directory.

Typically `.vs/` is used by Visual Studio as a cache and to store temporary local options (breakpoint locations etc).